### PR TITLE
enable invoke-push for siembol

### DIFF
--- a/.github/workflows/helm-chart.yaml
+++ b/.github/workflows/helm-chart.yaml
@@ -1,0 +1,13 @@
+name: Publish Helm Chart
+
+on: 
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  invoke-push:
+    uses: g-research/charts/.github/workflows/invoke-push.yaml@master
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
using proven `invoke-push.yaml` to use existing process of publishing helm charts to `G-Research/charts` repo

same as for `armada` - https://github.com/armadaproject/armada/blob/3403080157b36b68e5e2041dceca5ee04197dd32/.github/workflows/release.yml#L93

